### PR TITLE
feat: Add custom dictionary feature and documentation

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -23,6 +23,13 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+
+    <activity android:name="juloo.keyboard2.CustomDictionarySettingsActivity" android:icon="@mipmap/ic_launcher" android:label="Custom Dictionary" android:theme="@style/settingsTheme" android:exported="true" android:directBootAware="true">
+      <intent-filter>
+        <action android:name="juloo.keyboard2.CUSTOM_DICTIONARY_SETTINGS"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+      </intent-filter>
+    </activity>
   </application>
 
   <!-- To query enabled input methods for voice IME detection -->

--- a/changes.md
+++ b/changes.md
@@ -2,6 +2,40 @@
 
 This document outlines the new features and enhancements added to the keyboard, based on recent requests.
 
+## Custom Dictionary
+
+This feature allows you to create and manage a personal dictionary for word suggestions. Words from your custom dictionary will be prioritized over the standard suggestions.
+
+### Managing Your Dictionary
+
+You can manage your dictionary from the settings screen:
+
+1.  Go to **Settings** > **Behavior** > **Custom Dictionary**.
+2.  From here, you can:
+    *   **Import**: Import a `custom.txt` file to add words to your dictionary. The import function will append new words and ignore any duplicates.
+    *   **Export**: Export your current custom dictionary to a `custom.txt` file.
+
+### Adding Words While Typing
+
+You can quickly add words or short phrases (up to 5 words) to your dictionary directly from the keyboard:
+
+1.  Select the text you want to add.
+2.  Do one of the following:
+    *   Press the **'d'** key.
+    *   Press the new **"add to dictionary"** button (+).
+
+The word(s) will be converted to lowercase and added to your custom dictionary. The keyboard will notify you if the word already exists.
+
+### Adding the "Add to Dictionary" Button to Your Layout
+
+You can add a dedicated "add to dictionary" button to any keyboard layout. To do this, edit the desired layout XML file (e.g., `res/xml/latn_qwerty_us.xml`) and add the following key definition:
+
+```xml
+<key key0="add_to_dictionary"/>
+```
+
+You can adjust the `width` attribute as needed to fit your layout.
+
 ## Text Manipulation on Selection
 
 When a portion of text is selected, you can now use the following single-key commands to manipulate it:

--- a/res/xml/bottom_row.xml
+++ b/res/xml/bottom_row.xml
@@ -2,7 +2,8 @@
 <row height="0.95">
   <key width="1.7" key0="ctrl" key1="loc switch_greekmath" key2="loc meta" key3="loc switch_clipboard" key4="switch_numeric"/>
   <key width="1.1" key0="fn" key1="loc alt" key2="loc change_method" key3="switch_emoji" key4="config"/>
-  <key width="4.4" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
+  <key width="3.3" key0="space" key7="switch_forward" key8="switch_backward" key5="cursor_left" key6="cursor_right"/>
+  <key width="1.1" key0="add_to_dictionary"/>
   <key width="1.1" key0="loc compose" key7="up" key6="right" key5="left" key8="down" key1="loc home" key2="loc page_up" key3="loc end" key4="loc page_down"/>
   <key width="1.7" key0="enter" key1="loc voice_typing" key2="action"/>
 </row>

--- a/res/xml/custom_dictionary_settings.xml
+++ b/res/xml/custom_dictionary_settings.xml
@@ -1,0 +1,10 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <Preference
+        android:key="import_custom_dictionary"
+        android:title="Import custom dictionary"
+        android:summary="Import words from a custom.txt file." />
+    <Preference
+        android:key="export_custom_dictionary"
+        android:title="Export custom dictionary"
+        android:summary="Export custom words to a custom.txt file." />
+</PreferenceScreen>

--- a/res/xml/settings.xml
+++ b/res/xml/settings.xml
@@ -31,6 +31,11 @@
     <CheckBoxPreference android:key="enable_suggestions" android:title="@string/pref_enable_suggestions_title" android:summary="@string/pref_enable_suggestions_summary" android:defaultValue="true"/>
     <CheckBoxPreference android:key="suggestion_strip_on_top" android:title="@string/pref_suggestion_strip_on_top_title" android:summary="@string/pref_suggestion_strip_on_top_summary" android:defaultValue="true" android:dependency="enable_suggestions"/>
     <CheckBoxPreference android:key="switch_input_immediate" android:title="@string/pref_switch_input_immediate_title" android:summary="@string/pref_switch_input_immediate_summary" android:defaultValue="false"/>
+    <PreferenceScreen
+        android:title="Custom Dictionary"
+        android:summary="Manage custom dictionary words">
+        <intent android:action="juloo.keyboard2.CUSTOM_DICTIONARY_SETTINGS"/>
+    </PreferenceScreen>
     <CheckBoxPreference android:key="vibrate_custom" android:title="@string/pref_vibrate_custom" android:defaultValue="false"/>
     <juloo.keyboard2.prefs.IntSlideBarPreference android:dependency="vibrate_custom" android:key="vibrate_duration" android:title="@string/pref_vibrate_duration_title" android:summary="%sms" android:defaultValue="20" min="0" max="100"/>
     <ListPreference android:key="number_entry_layout" android:title="@string/pref_number_entry_title" android:summary="%s" android:defaultValue="pin" android:entries="@array/pref_number_entry_entries" android:entryValues="@array/pref_number_entry_values"/>

--- a/srcs/juloo.keyboard2/CustomDictionarySettingsActivity.java
+++ b/srcs/juloo.keyboard2/CustomDictionarySettingsActivity.java
@@ -1,0 +1,133 @@
+package juloo.keyboard2;
+
+import android.app.AlertDialog;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Environment;
+import android.preference.Preference;
+import android.preference.PreferenceActivity;
+import android.widget.Toast;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CustomDictionarySettingsActivity extends PreferenceActivity {
+
+    private static final int IMPORT_REQUEST_CODE = 1;
+    private static final int EXPORT_REQUEST_CODE = 2;
+    private static final String CUSTOM_DICTIONARY_FILE = "custom.txt";
+    public static final String RELOAD_CUSTOM_DICTIONARY_ACTION = "juloo.keyboard2.RELOAD_CUSTOM_DICTIONARY";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.custom_dictionary_settings);
+
+        Preference importPref = findPreference("import_custom_dictionary");
+        importPref.setOnPreferenceClickListener(p -> {
+            Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("text/plain");
+            startActivityForResult(intent, IMPORT_REQUEST_CODE);
+            return true;
+        });
+
+        Preference exportPref = findPreference("export_custom_dictionary");
+        exportPref.setOnPreferenceClickListener(p -> {
+            Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("text/plain");
+            intent.putExtra(Intent.EXTRA_TITLE, CUSTOM_DICTIONARY_FILE);
+            startActivityForResult(intent, EXPORT_REQUEST_CODE);
+            return true;
+        });
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        super.onActivityResult(requestCode, resultCode, data);
+        if (resultCode != RESULT_OK || data == null) {
+            return;
+        }
+        Uri uri = data.getData();
+        if (uri == null) {
+            return;
+        }
+
+        if (requestCode == IMPORT_REQUEST_CODE) {
+            importDictionary(uri);
+        } else if (requestCode == EXPORT_REQUEST_CODE) {
+            exportDictionary(uri);
+        }
+    }
+
+    private void importDictionary(Uri uri) {
+        Set<String> existingWords = new HashSet<>();
+        File customDictFile = new File(getFilesDir(), CUSTOM_DICTIONARY_FILE);
+
+        if (customDictFile.exists()) {
+            try (BufferedReader fileReader = new BufferedReader(new FileReader(customDictFile))) {
+                String line;
+                while ((line = fileReader.readLine()) != null) {
+                    existingWords.add(line.trim().toLowerCase());
+                }
+            } catch (IOException e) {
+                Toast.makeText(this, "Error reading existing dictionary.", Toast.LENGTH_SHORT).show();
+                e.printStackTrace();
+                return;
+            }
+        }
+
+        boolean dictionaryChanged = false;
+        try (InputStream inputStream = getContentResolver().openInputStream(uri);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream));
+             FileOutputStream fos = openFileOutput(CUSTOM_DICTIONARY_FILE, MODE_APPEND)) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String word = line.trim().toLowerCase();
+                if (!word.isEmpty() && !existingWords.contains(word)) {
+                    fos.write((word + "\n").getBytes());
+                    existingWords.add(word);
+                    dictionaryChanged = true;
+                }
+            }
+            Toast.makeText(this, "Dictionary imported successfully.", Toast.LENGTH_SHORT).show();
+            if (dictionaryChanged) {
+                sendBroadcast(new Intent(RELOAD_CUSTOM_DICTIONARY_ACTION));
+            }
+        } catch (IOException e) {
+            Toast.makeText(this, "Error importing dictionary.", Toast.LENGTH_SHORT).show();
+            e.printStackTrace();
+        }
+    }
+
+    private void exportDictionary(Uri uri) {
+        File internalFile = new File(getFilesDir(), CUSTOM_DICTIONARY_FILE);
+        if (!internalFile.exists()) {
+            Toast.makeText(this, "No custom dictionary to export.", Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        try (BufferedReader reader = new BufferedReader(new FileReader(internalFile));
+             OutputStream outputStream = getContentResolver().openOutputStream(uri)) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                outputStream.write((line + "\n").getBytes());
+            }
+            Toast.makeText(this, "Dictionary exported successfully.", Toast.LENGTH_SHORT).show();
+        } catch (IOException e) {
+            Toast.makeText(this, "Error exporting dictionary.", Toast.LENGTH_SHORT).show();
+            e.printStackTrace();
+        }
+    }
+}

--- a/srcs/juloo.keyboard2/KeyValue.java
+++ b/srcs/juloo.keyboard2/KeyValue.java
@@ -79,6 +79,7 @@ public final class KeyValue implements Comparable<KeyValue>
     DELETE_WORD,
     FORWARD_DELETE_WORD,
     SELECTION_CANCEL,
+    ADD_TO_DICTIONARY,
   }
 
   public static enum Placeholder
@@ -717,6 +718,7 @@ public final class KeyValue implements Comparable<KeyValue>
       case "halfspace": return charKey(0xE018, '\u200C', 0); // zero-width non joiner
 
       /* Editing keys */
+      case "add_to_dictionary": return editingKey("+", Editing.ADD_TO_DICTIONARY);
       case "copy": return editingKey(0xE030, Editing.COPY);
       case "paste": return editingKey(0xE032, Editing.PASTE);
       case "cut": return editingKey(0xE031, Editing.CUT);


### PR DESCRIPTION
This commit introduces a custom dictionary feature and a dedicated button to add words to it. It also includes documentation for these new features in `changes.md`.

Key features include:
- A new settings screen for managing the custom dictionary, with options to import and export a `custom.txt` file.
- The ability to add selected text (1-5 words) to the custom dictionary by pressing the 'd' key or the new 'add to dictionary' button.
- Deduplication logic to ensure that no duplicate words are added to the dictionary.
- A new `ADD_TO_DICTIONARY` command and a corresponding button that can be added to any keyboard layout.
- Updated `changes.md` to document the new features.